### PR TITLE
fix dependency not found problem: widgets_2.6_

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,12 @@
             <name>Scala-Tools Dependencies Repository for Snapshots</name>
             <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
         </repository>
+        <!--fetch lift framework related dependencies-->
+        <repository>
+        <id>jboss-public-repository-group</id>
+        <name>JBoss Public Repository Group</name>
+        <url>http://repository.jboss.org/nexus/content/groups/public</url>
+    </repository>
     </repositories>
 
     <pluginRepositories>


### PR DESCRIPTION
the follow dependency can't be fetched:
```
        <dependency>
            <groupId>net.liftmodules</groupId>
            <artifactId>widgets_2.6_${scala.version}</artifactId>
            <version>1.4-SNAPSHOT</version>
        </dependency>
```
it is in the jboss repository, so here add that repository, to make sure if local repository have no that dependency, it also can pass compile.