### PR TITLE
Fix compile error caused by js arrow function

### DIFF
--- a/src/main/webapp/media/js/website.js
+++ b/src/main/webapp/media/js/website.js
@@ -294,7 +294,9 @@ function copyJsonResultToClipboard(element) {
   // It delays the call by ms milliseconds
   function defer(f, ms) {
     return function() {
-      setTimeout(() => f.apply(this, arguments), ms);
+      setTimeout(function() {
+          f.apply(this, arguments);
+      }, ms);
     };
   }
   


### PR DESCRIPTION
Fix compile error when run: **mvn compile**

<img width="734" alt="image" src="https://user-images.githubusercontent.com/2577334/201514155-45d11999-3fef-434e-83c3-958132d7ba27.png">
